### PR TITLE
Fixed import of testpipe, so that --dotest runs as normal now

### DIFF
--- a/sndrizpipe/runpipe_cmdline.py
+++ b/sndrizpipe/runpipe_cmdline.py
@@ -1163,7 +1163,7 @@ def main():
     argv = parser.parse_args()
 
     if argv.dotest:
-        import testpipe
+        from sndrizpipe import testpipe
         testpipe.colfaxtest(getflts=True, runpipeline=True)
         return 0
 


### PR DESCRIPTION
I was able to get --dotest to run as normal after making this change. The original way of writing it was probably using a cached version of import. This should make it work on all computers.

-Caleb